### PR TITLE
Onboarding: 3-Step fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,23 +107,30 @@ Screenshot/GIF
 Full doc
 - See `docs/screens/customize.md` for flow, UI, state, routing, and testing notes.
 
-## Onboarding (Issue #2)
+## Onboarding (3 steps)
 
 What it does
-- Adds an Onboarding screen stub wired into routing.
-- Serves as the first step in the 6-screen flow, to be expanded with preferences and first-run logic.
+- Guides first-time users through Country → Level → Diet selections using a single primary CTA on each screen.
+- Captures choices with Riverpod state and persists them to `SharedPreferences` so the flow only runs once per user.
+- Redirects completed users straight to Home on subsequent launches via the go_router startup guard.
 
 Where the code lives
-- Screen: `lib/features/onboarding/onboarding_screen.dart`
-- Route: `/onboarding` in `lib/router/app_router.dart` and `lib/router/routes.dart`
+- Step screens: `lib/features/onboarding/step_country.dart`, `lib/features/onboarding/step_level.dart`, `lib/features/onboarding/step_diet.dart`
+- Shared widgets: `lib/features/onboarding/onboarding_widgets.dart`
+- State & persistence: `lib/app/state/onboarding_state.dart`, `lib/app/services/preferences_service.dart`
+- Routing: `lib/router/app_router.dart`, `lib/router/routes.dart`
 
 How it fits
-- Entry point for user setup before browsing and customizing recipes.
-- Will set initial preferences (time, servings, spice) and mark onboarding as complete for future launches.
+- Fulfills the onboarding portion of the six-screen MVP flow before delivering personalized recipes on Home.
+- Stores core dietary preferences that downstream features can read without re-prompting the user.
+- Uses the same design tokens as the rest of the app to stay visually consistent and accessible.
 
 Dependencies
+- State: `riverpod`
+- Persistence: `shared_preferences`
 - Routing: `go_router`
-- Planned: `SharedPreferences` for first-run flag and onboarding completion state
 
 Screenshot/GIF
-- [Placeholder: onboarding-screen.png]
+- [Placeholder: onboarding-country.png]
+- [Placeholder: onboarding-level.png]
+- [Placeholder: onboarding-diet.png]

--- a/docs/dev/dartdoc_onboarding.md
+++ b/docs/dev/dartdoc_onboarding.md
@@ -1,0 +1,8 @@
+# Onboarding Dartdoc Snippets
+
+```
+/// OnboardingController — manages selections and persistence for Country→Level→Diet.
+/// PreferencesService — wrapper for onboarding keys in SharedPreferences.
+/// StepCountry/StepLevel/StepDiet — token-based screens with a single primary CTA.
+/// Onboarding startup guard reads controller state restored from preferences.
+```

--- a/docs/screens/onboarding.md
+++ b/docs/screens/onboarding.md
@@ -1,40 +1,54 @@
-# Onboarding
+# Onboarding (Country → Level → Diet)
 
-## Purpose
-- Introduce OnePan, collect initial preferences, and set first-run state for future launches.
+## Overview & Rationale
+- First-run funnel that gathers the minimum preferences needed to personalize OnePan recommendations.
+- Keeps the experience focused: three lightweight decisions that influence recipe surfaces without overwhelming the user.
+- Runs once per install unless preferences are cleared, thanks to SharedPreferences-backed persistence.
 
-## User Flow
-1) Launch app and see onboarding.
-2) Set core preferences (time, servings, spice) — planned.
-3) Continue to Home and mark onboarding complete.
+## Steps & UI Rules
+1. **Country** — grid of regional chips; select exactly one to continue.
+2. **Level** — segmented control for Beginner, Intermediate, Advanced.
+3. **Diet** — checklist-style chips for Omnivore, Vegetarian, Vegan, Pescatarian, and Gluten-Free.
 
-## Technical Flow
-- Route: `/onboarding` (go_router).
-- Preferences: planned `SharedPreferences` key (e.g., `onboarding_completed = true`).
-- First-run logic: if not completed, start at `/onboarding`; else go to `/home`.
+Design constraints
+- Token-only spacing, typography, radii, colors, and elevation (no raw values).
+- One primary CTA per screen (“Next” or “Finish”), disabled until a selection exists.
+- Touch targets ≥48dp achieved through tokenized padding in `OptionGrid` and CTA widgets.
+- Back navigation via AppBar leading icon; selection states expose semantics for accessibility.
 
-Current Status
-- Screen stub with title text.
-- Router wiring in place.
-- No preferences or first-run guard implemented yet.
+## State & Persistence
+- **OnboardingController** (`lib/app/state/onboarding_state.dart`) stores in-progress selections with a Riverpod `StateNotifier`.
+- **PreferencesService** (`lib/app/services/preferences_service.dart`) persists `country`, `level`, `diet`, and `onboarding.complete` keys to `SharedPreferences`.
+- `complete()` validates that all selections exist, saves them, and marks onboarding complete for future launches.
 
-## Relevant File Paths
-- Screen: `lib/features/onboarding/onboarding_screen.dart`
-- Router: `lib/router/app_router.dart`, `lib/router/routes.dart`
+### Preference Keys
+- `onboarding.country`
+- `onboarding.level`
+- `onboarding.diet`
+- `onboarding.complete`
 
-## How To Change Onboarding Behavior
-- Update the widget in `lib/features/onboarding/onboarding_screen.dart`.
-- Add preferences logic:
-  - Write completion flag via `SharedPreferences`.
-  - Add redirect in `GoRouter` (e.g., `redirect` callback) to send first-run users to `/onboarding`.
-- Update tests to cover:
-  - First run (onboarding shows).
-  - Subsequent runs (home shows).
+## Routing
+- `go_router` startup redirect reads the `OnboardingController` state (restored from `PreferencesService`) before resolving the initial route.
+- First-run users start at `/onboarding/country`, progress through `/onboarding/level` and `/onboarding/diet`, then land on `/home` after completion.
+- Returning users bypass onboarding entirely and load `/home` immediately.
+
+## How to Test
+- Inject a mocked `PreferencesService` via provider overrides to simulate stored values.
+- Pump each onboarding step widget with Riverpod test harness to verify CTA enablement, semantics, and navigation callbacks.
+- Verify redirect logic by seeding the `OnboardingController` state (complete/incomplete) and asserting the initial location.
+
+## File Locations
+- `lib/app/services/preferences_service.dart`
+- `lib/app/state/onboarding_state.dart`
+- `lib/di/locator.dart`
+- `lib/router/app_router.dart`
+- `lib/features/onboarding/onboarding_widgets.dart`
+- `lib/features/onboarding/step_country.dart`
+- `lib/features/onboarding/step_level.dart`
+- `lib/features/onboarding/step_diet.dart`
 
 ## Future Enhancements
-- Persist onboarding completion to `SharedPreferences`.
-- Capture and store preferences (time/servings/spice).
-- Accessibility sizing and state handling per UI_Principles.md.
-- Localized copy and illustrations.
-- Analytics hooks (post-MVP).
+- Add “Skip for now” affordance with persistence toggle.
+- Surface an “Edit preferences” entry in Settings/Home once flows exist.
+- Localize copy and diversify imagery post-MVP.
 

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,14 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:onepan/router/app_router.dart';
+import 'package:onepan/theme/app_theme.dart';
 
 class OnePanApp extends StatelessWidget {
   const OnePanApp({super.key});
 
   @override
   Widget build(BuildContext context) {
+    return const ProviderScope(
+      child: _OnePanAppView(),
+    );
+  }
+}
+
+class _OnePanAppView extends ConsumerWidget {
+  const _OnePanAppView();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+
     return MaterialApp.router(
       title: 'OnePan',
-      routerConfig: appRouter,
+      theme: AppTheme.light(),
+      darkTheme: AppTheme.dark(),
+      routerConfig: router,
     );
   }
 }

--- a/lib/app/services/preferences_service.dart
+++ b/lib/app/services/preferences_service.dart
@@ -1,0 +1,68 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PreferencesService {
+  PreferencesService();
+
+  static const _countryKey = 'onboarding.country';
+  static const _levelKey = 'onboarding.level';
+  static const _dietKey = 'onboarding.diet';
+  static const _completeKey = 'onboarding.complete';
+
+  SharedPreferences? _cachedPreferences;
+
+  Future<SharedPreferences> get _instance async {
+    return _cachedPreferences ??=
+        await SharedPreferences.getInstance();
+  }
+
+  Future<bool> isOnboardingComplete() async {
+    final prefs = await _instance;
+    return prefs.getBool(_completeKey) ?? false;
+  }
+
+  Future<void> saveOnboarding({
+    required String country,
+    required String level,
+    required String diet,
+  }) async {
+    final prefs = await _instance;
+    await prefs.setString(_countryKey, country);
+    await prefs.setString(_levelKey, level);
+    await prefs.setString(_dietKey, diet);
+    await prefs.setBool(_completeKey, true);
+  }
+
+  Future<Map<String, String>?> readOnboarding() async {
+    final prefs = await _instance;
+    final isComplete = prefs.getBool(_completeKey) ?? false;
+    if (!isComplete) {
+      return null;
+    }
+
+    final country = prefs.getString(_countryKey);
+    final level = prefs.getString(_levelKey);
+    final diet = prefs.getString(_dietKey);
+
+    if (country == null || level == null || diet == null) {
+      return null;
+    }
+
+    if (country.isEmpty || level.isEmpty || diet.isEmpty) {
+      return null;
+    }
+
+    return {
+      'country': country,
+      'level': level,
+      'diet': diet,
+    };
+  }
+
+  Future<void> clearOnboarding() async {
+    final prefs = await _instance;
+    await prefs.remove(_countryKey);
+    await prefs.remove(_levelKey);
+    await prefs.remove(_dietKey);
+    await prefs.setBool(_completeKey, false);
+  }
+}

--- a/lib/app/state/onboarding_state.dart
+++ b/lib/app/state/onboarding_state.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:onepan/app/services/preferences_service.dart';
+
+@immutable
+class OnboardingState {
+  const OnboardingState({
+    this.country,
+    this.level,
+    this.diet,
+  });
+
+  final String? country;
+  final String? level;
+  final String? diet;
+
+  bool get isComplete => country != null && level != null && diet != null;
+
+  OnboardingState copyWith({
+    String? country,
+    String? level,
+    String? diet,
+  }) {
+    return OnboardingState(
+      country: country ?? this.country,
+      level: level ?? this.level,
+      diet: diet ?? this.diet,
+    );
+  }
+}
+
+class OnboardingController extends StateNotifier<OnboardingState> {
+  OnboardingController(this._preferences) : super(const OnboardingState()) {
+    _restoreFromPreferences();
+  }
+
+  final PreferencesService _preferences;
+
+  Future<void> _restoreFromPreferences() async {
+    final saved = await _preferences.readOnboarding();
+    if (saved == null) {
+      return;
+    }
+
+    state = OnboardingState(
+      country: saved['country'],
+      level: saved['level'],
+      diet: saved['diet'],
+    );
+  }
+
+  void selectCountry(String country) {
+    state = state.copyWith(country: country);
+  }
+
+  void selectLevel(String level) {
+    state = state.copyWith(level: level);
+  }
+
+  void selectDiet(String diet) {
+    state = state.copyWith(diet: diet);
+  }
+
+  Future<void> complete() async {
+    final current = state;
+    if (!current.isComplete) {
+      throw ArgumentError('Cannot complete onboarding without all selections.');
+    }
+
+    await _preferences.saveOnboarding(
+      country: current.country!,
+      level: current.level!,
+      diet: current.diet!,
+    );
+
+    state = OnboardingState(
+      country: current.country,
+      level: current.level,
+      diet: current.diet,
+    );
+  }
+
+  Future<void> clear() async {
+    await _preferences.clearOnboarding();
+    state = const OnboardingState();
+  }
+}

--- a/lib/di/locator.dart
+++ b/lib/di/locator.dart
@@ -1,5 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 
+import 'package:onepan/app/services/preferences_service.dart';
+import 'package:onepan/app/state/onboarding_state.dart';
 import 'package:onepan/repository/mock_substitution_repository.dart';
 import 'package:onepan/repository/seed_recipe_repository.dart';
 import 'package:onepan/repository/recipe_repository.dart';
@@ -33,3 +36,15 @@ void setupLocator() {
 
 // Convenience accessor to keep UI concise and source-agnostic.
 T locator<T extends Object>() => getIt<T>();
+
+/// Shared preferences wrapper for onboarding and other persisted settings.
+final preferencesServiceProvider = Provider<PreferencesService>((ref) {
+  return PreferencesService();
+});
+
+/// State holder for onboarding selections and completion persistence.
+final onboardingControllerProvider =
+    StateNotifierProvider<OnboardingController, OnboardingState>((ref) {
+  final service = ref.read(preferencesServiceProvider);
+  return OnboardingController(service);
+});

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,18 +1,16 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import 'step_country.dart';
+
+export 'step_country.dart';
+export 'step_diet.dart';
+export 'step_level.dart';
 
 class OnboardingScreen extends StatelessWidget {
   const OnboardingScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text(
-          'Onboarding',
-          textAlign: TextAlign.center,
-        ),
-      ),
-    );
+    return const OnboardingCountryScreen();
   }
 }
-

--- a/lib/features/onboarding/onboarding_widgets.dart
+++ b/lib/features/onboarding/onboarding_widgets.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:onepan/theme/tokens.dart';
+
+class SectionHeader extends StatelessWidget {
+  const SectionHeader({
+    super.key,
+    required this.stepLabel,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final String stepLabel;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          stepLabel,
+          style: AppTextStyles.label.copyWith(
+            color: AppColors.onSurface.withValues(alpha: AppOpacity.mediumText),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          title,
+          style: AppTextStyles.headline.copyWith(
+            color: AppColors.onSurface,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          subtitle,
+          style: AppTextStyles.body.copyWith(
+            color: AppColors.onSurface.withValues(alpha: AppOpacity.mediumText),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+enum OptionGridStyle { grid, segmented }
+
+class OptionGrid extends StatelessWidget {
+  const OptionGrid({
+    super.key,
+    required this.options,
+    required this.selectedOption,
+    required this.onSelected,
+    this.style = OptionGridStyle.grid,
+  });
+
+  final List<String> options;
+  final String? selectedOption;
+  final ValueChanged<String> onSelected;
+  final OptionGridStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (style) {
+      case OptionGridStyle.grid:
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            final canShowTwoColumns =
+                constraints.maxWidth >= (AppSizes.minTouchTarget * 2) + AppSpacing.md;
+            final itemWidth = canShowTwoColumns
+                ? (constraints.maxWidth - AppSpacing.md) / 2
+                : constraints.maxWidth;
+
+            return Wrap(
+              spacing: AppSpacing.md,
+              runSpacing: AppSpacing.md,
+              children: options
+                  .map(
+                    (option) => SizedBox(
+                      width: itemWidth,
+                      child: _OptionTile(
+                        label: option,
+                        selected: option == selectedOption,
+                        onTap: () => onSelected(option),
+                        centerLabel: false,
+                      ),
+                    ),
+                  )
+                  .toList(),
+            );
+          },
+        );
+      case OptionGridStyle.segmented:
+        return Row(
+          children: [
+            for (var index = 0; index < options.length; index++)
+              Expanded(
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: index == 0 ? 0 : AppSpacing.sm,
+                    right: index == options.length - 1 ? 0 : AppSpacing.sm,
+                  ),
+                  child: _OptionTile(
+                    label: options[index],
+                    selected: options[index] == selectedOption,
+                    onTap: () => onSelected(options[index]),
+                    centerLabel: true,
+                  ),
+                ),
+              ),
+          ],
+        );
+    }
+  }
+}
+
+class PrimaryCTA extends StatelessWidget {
+  const PrimaryCTA({
+    super.key,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final Future<void> Function()? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: FilledButton(
+        onPressed:
+            onPressed == null ? null : () => unawaited(onPressed!.call()),
+        style: FilledButton.styleFrom(
+          minimumSize: const Size.fromHeight(AppSizes.minTouchTarget),
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+          backgroundColor: AppColors.primary,
+          foregroundColor: AppColors.onPrimary,
+          textStyle: AppTextStyles.title,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadii.md),
+          ),
+        ),
+        child: Text(label),
+      ),
+    );
+  }
+}
+
+class _OptionTile extends StatelessWidget {
+  const _OptionTile({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    required this.centerLabel,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final bool centerLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final baseStyle = selected ? AppTextStyles.title : AppTextStyles.body;
+    final textStyle = baseStyle.copyWith(
+      color: selected ? AppColors.onPrimary : AppColors.onSurface,
+    );
+
+    final backgroundColor = selected ? AppColors.primary : AppColors.surface;
+    final borderColor = selected
+        ? AppColors.primary
+        : AppColors.onSurface.withValues(alpha: AppOpacity.hover);
+
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      child: Material(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppRadii.md),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppRadii.md),
+          onTap: onTap,
+          child: AnimatedContainer(
+            duration: AppDurations.fast,
+            decoration: BoxDecoration(
+              color: backgroundColor,
+              borderRadius: BorderRadius.circular(AppRadii.md),
+              border: Border.all(
+                color: borderColor,
+                width: AppThickness.stroke,
+              ),
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.md,
+            ),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(
+                minHeight: AppSizes.minTouchTarget,
+              ),
+              child: Align(
+                alignment:
+                    centerLabel ? Alignment.center : Alignment.centerLeft,
+                child: Text(label, textAlign: centerLabel ? TextAlign.center : TextAlign.start, style: textStyle),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/step_country.dart
+++ b/lib/features/onboarding/step_country.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:onepan/di/locator.dart';
+import 'package:onepan/features/onboarding/onboarding_widgets.dart';
+import 'package:onepan/router/routes.dart';
+import 'package:onepan/theme/tokens.dart';
+
+class OnboardingCountryScreen extends ConsumerWidget {
+  const OnboardingCountryScreen({super.key});
+
+  static const _countries = <String>[
+    'Europe',
+    'Asia',
+    'Americas',
+    'Africa',
+    'Oceania',
+    'Middle East',
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(onboardingControllerProvider);
+    final controller = ref.read(onboardingControllerProvider.notifier);
+    final canProceed = state.country != null;
+
+    return Scaffold(
+      backgroundColor: AppColors.surface,
+      appBar: AppBar(
+        backgroundColor: AppColors.surface,
+        elevation: AppElevation.e0,
+        iconTheme: const IconThemeData(color: AppColors.onSurface),
+        title: Text(
+          'Step 1 of 3',
+          style: AppTextStyles.label.copyWith(color: AppColors.onSurface),
+        ),
+        leading: const BackButton(),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SectionHeader(
+                stepLabel: 'Country',
+                title: 'Where are you cooking from?',
+                subtitle: 'Pick your region to surface region-friendly recipes.',
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: OptionGrid(
+                    options: _countries,
+                    selectedOption: state.country,
+                    onSelected: controller.selectCountry,
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+              PrimaryCTA(
+                label: 'Next',
+                onPressed: canProceed
+                    ? () async {
+                        if (state.country == null) {
+                          return;
+                        }
+                        context.go(Routes.onboardingLevel);
+                      }
+                    : null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/step_diet.dart
+++ b/lib/features/onboarding/step_diet.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:onepan/di/locator.dart';
+import 'package:onepan/features/onboarding/onboarding_widgets.dart';
+import 'package:onepan/router/routes.dart';
+import 'package:onepan/theme/tokens.dart';
+
+class OnboardingDietScreen extends ConsumerWidget {
+  const OnboardingDietScreen({super.key});
+
+  static const _diets = <String>[
+    'Omnivore',
+    'Vegetarian',
+    'Vegan',
+    'Pescatarian',
+    'Gluten-Free',
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(onboardingControllerProvider);
+    final controller = ref.read(onboardingControllerProvider.notifier);
+    final canFinish = state.diet != null;
+
+    return Scaffold(
+      backgroundColor: AppColors.surface,
+      appBar: AppBar(
+        backgroundColor: AppColors.surface,
+        elevation: AppElevation.e0,
+        iconTheme: const IconThemeData(color: AppColors.onSurface),
+        title: Text(
+          'Step 3 of 3',
+          style: AppTextStyles.label.copyWith(color: AppColors.onSurface),
+        ),
+        leading: const BackButton(),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SectionHeader(
+                stepLabel: 'Diet',
+                title: 'Any dietary preferences?',
+                subtitle: 'We keep ingredient swaps aligned to your needs.',
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: OptionGrid(
+                    options: _diets,
+                    selectedOption: state.diet,
+                    onSelected: controller.selectDiet,
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+              PrimaryCTA(
+                label: 'Finish',
+                onPressed: canFinish
+                    ? () async {
+                        if (state.diet == null) {
+                          return;
+                        }
+                        await controller.complete();
+                        if (!context.mounted) {
+                          return;
+                        }
+                        context.go(Routes.home);
+                      }
+                    : null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/step_level.dart
+++ b/lib/features/onboarding/step_level.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:onepan/di/locator.dart';
+import 'package:onepan/features/onboarding/onboarding_widgets.dart';
+import 'package:onepan/router/routes.dart';
+import 'package:onepan/theme/tokens.dart';
+
+class OnboardingLevelScreen extends ConsumerWidget {
+  const OnboardingLevelScreen({super.key});
+
+  static const _levels = <String>[
+    'Beginner',
+    'Intermediate',
+    'Advanced',
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(onboardingControllerProvider);
+    final controller = ref.read(onboardingControllerProvider.notifier);
+    final canProceed = state.level != null;
+
+    return Scaffold(
+      backgroundColor: AppColors.surface,
+      appBar: AppBar(
+        backgroundColor: AppColors.surface,
+        elevation: AppElevation.e0,
+        iconTheme: const IconThemeData(color: AppColors.onSurface),
+        title: Text(
+          'Step 2 of 3',
+          style: AppTextStyles.label.copyWith(color: AppColors.onSurface),
+        ),
+        leading: const BackButton(),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SectionHeader(
+                stepLabel: 'Skill Level',
+                title: 'How confident are you in the kitchen?',
+                subtitle: 'We tune instructions and shortcuts to your comfort level.',
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              Expanded(
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: OptionGrid(
+                    options: _levels,
+                    selectedOption: state.level,
+                    onSelected: controller.selectLevel,
+                    style: OptionGridStyle.segmented,
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+              PrimaryCTA(
+                label: 'Next',
+                onPressed: canProceed
+                    ? () async {
+                        if (state.level == null) {
+                          return;
+                        }
+                        context.go(Routes.onboardingDiet);
+                      }
+                    : null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:onepan/di/locator.dart';
 export 'package:onepan/app/app.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   // Set up dependency injection
   setupLocator();
   runApp(const OnePanApp());

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -1,67 +1,117 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:onepan/router/routes.dart';
-import 'package:onepan/features/onboarding/onboarding_screen.dart';
-import 'package:onepan/features/home/home_screen.dart';
+
+import 'package:onepan/di/locator.dart';
 import 'package:onepan/features/customize/customize_screen.dart';
-import 'package:onepan/features/ingredients/ingredients_screen.dart';
 import 'package:onepan/features/finalizer/finalizer_screen.dart';
+import 'package:onepan/features/home/home_screen.dart';
+import 'package:onepan/features/ingredients/ingredients_screen.dart';
+import 'package:onepan/features/onboarding/onboarding_screen.dart';
 import 'package:onepan/features/recipe/recipe_screen.dart';
-import 'package:onepan/screens/dev/recipe_detail_screen.dart';
-import 'package:onepan/screens/dev/recipes_list_screen.dart';
 import 'package:onepan/models/recipe.dart';
 import 'package:onepan/dev/components_demo_screen.dart';
+import 'package:onepan/router/routes.dart';
+import 'package:onepan/router/go_router_refresh_stream.dart';
+import 'package:onepan/screens/dev/recipe_detail_screen.dart';
+import 'package:onepan/screens/dev/recipes_list_screen.dart';
 
-// Central app router configuration using go_router.
-final GoRouter appRouter = GoRouter(
-  // Keep home as initial to satisfy tests; dev listing accessible via Home button.
-  initialLocation: Routes.home,
-  routes: <RouteBase>[
-    GoRoute(
-      path: Routes.onboarding,
-      name: 'onboarding',
-      builder: (context, state) => const OnboardingScreen(),
-    ),
-    GoRoute(
-      path: Routes.home,
-      name: 'home',
-      builder: (context, state) => const HomeScreen(),
-    ),
-    GoRoute(
-      path: Routes.customize,
-      name: 'customize',
-      builder: (context, state) => const CustomizeScreen(),
-    ),
-    GoRoute(
-      path: Routes.ingredients,
-      name: 'ingredients',
-      builder: (context, state) => const IngredientsScreen(),
-    ),
-    GoRoute(
-      path: Routes.finalizer,
-      name: 'finalizer',
-      builder: (context, state) => const FinalizerScreen(),
-    ),
-    GoRoute(
-      path: Routes.recipe,
-      name: 'recipe',
-      builder: (context, state) => const RecipeScreen(),
-    ),
-    // Dev-only minimal listing/detail routes
-    GoRoute(
-      path: Routes.devRecipes,
-      name: 'dev_recipes',
-      builder: (context, state) => const RecipesListScreen(),
-    ),
-    GoRoute(
-      path: '${Routes.devRecipeBase}/:id',
-      name: 'dev_recipe_detail',
-      builder: (context, state) =>
-          RecipeDetailScreen(recipe: state.extra as Recipe),
-    ),
-    GoRoute(
-      path: Routes.devComponents,
-      name: 'dev_components',
-      builder: (context, state) => const ComponentsDemoScreen(),
-    ),
-  ],
-);
+final _rootNavigatorKey = GlobalKey<NavigatorState>();
+
+final appRouterProvider = Provider<GoRouter>((ref) {
+  final onboardingNotifier = ref.read(onboardingControllerProvider.notifier);
+  final refreshListenable = GoRouterRefreshStream(onboardingNotifier.stream);
+  ref.onDispose(refreshListenable.dispose);
+
+  const onboardingPaths = <String>{
+    Routes.onboarding,
+    Routes.onboardingCountry,
+    Routes.onboardingLevel,
+    Routes.onboardingDiet,
+  };
+
+  return GoRouter(
+    navigatorKey: _rootNavigatorKey,
+    initialLocation: Routes.onboardingCountry,
+    refreshListenable: refreshListenable,
+    redirect: (context, state) {
+      final isComplete = ref.read(onboardingControllerProvider).isComplete;
+      final location = state.uri.path.isEmpty
+          ? Routes.onboardingCountry
+          : state.uri.path;
+      final inOnboarding = onboardingPaths.contains(location);
+
+      if (!isComplete && !inOnboarding) {
+        return Routes.onboardingCountry;
+      }
+
+      if (isComplete && inOnboarding) {
+        return Routes.home;
+      }
+
+      return null;
+    },
+    routes: <RouteBase>[
+      GoRoute(
+        path: Routes.onboarding,
+        redirect: (_, __) => Routes.onboardingCountry,
+      ),
+      GoRoute(
+        path: Routes.onboardingCountry,
+        name: 'onboarding_country',
+        builder: (context, state) => const OnboardingCountryScreen(),
+      ),
+      GoRoute(
+        path: Routes.onboardingLevel,
+        name: 'onboarding_level',
+        builder: (context, state) => const OnboardingLevelScreen(),
+      ),
+      GoRoute(
+        path: Routes.onboardingDiet,
+        name: 'onboarding_diet',
+        builder: (context, state) => const OnboardingDietScreen(),
+      ),
+      GoRoute(
+        path: Routes.home,
+        name: 'home',
+        builder: (context, state) => const HomeScreen(),
+      ),
+      GoRoute(
+        path: Routes.customize,
+        name: 'customize',
+        builder: (context, state) => const CustomizeScreen(),
+      ),
+      GoRoute(
+        path: Routes.ingredients,
+        name: 'ingredients',
+        builder: (context, state) => const IngredientsScreen(),
+      ),
+      GoRoute(
+        path: Routes.finalizer,
+        name: 'finalizer',
+        builder: (context, state) => const FinalizerScreen(),
+      ),
+      GoRoute(
+        path: Routes.recipe,
+        name: 'recipe',
+        builder: (context, state) => const RecipeScreen(),
+      ),
+      GoRoute(
+        path: Routes.devRecipes,
+        name: 'dev_recipes',
+        builder: (context, state) => const RecipesListScreen(),
+      ),
+      GoRoute(
+        path: '${Routes.devRecipeBase}/:id',
+        name: 'dev_recipe_detail',
+        builder: (context, state) =>
+            RecipeDetailScreen(recipe: state.extra as Recipe),
+      ),
+      GoRoute(
+        path: Routes.devComponents,
+        name: 'dev_components',
+        builder: (context, state) => const ComponentsDemoScreen(),
+      ),
+    ],
+  );
+});

--- a/lib/router/go_router_refresh_stream.dart
+++ b/lib/router/go_router_refresh_stream.dart
@@ -1,0 +1,23 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// A simple [Listenable] that notifies listeners whenever the provided
+/// [Stream] emits an event. Useful for wiring provider/notifier changes into
+/// `GoRouter.refreshListenable` without coupling to UI frameworks.
+class GoRouterRefreshStream extends ChangeNotifier {
+  GoRouterRefreshStream(Stream<dynamic> stream) {
+    _subscription = stream.asBroadcastStream().listen((_) {
+      notifyListeners();
+    });
+  }
+
+  late final StreamSubscription<dynamic> _subscription;
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+}
+

--- a/lib/router/routes.dart
+++ b/lib/router/routes.dart
@@ -4,6 +4,9 @@ class Routes {
   Routes._();
 
   static const onboarding = '/onboarding';
+  static const onboardingCountry = '/onboarding/country';
+  static const onboardingLevel = '/onboarding/level';
+  static const onboardingDiet = '/onboarding/diet';
   static const home = '/home';
   static const customize = '/customize';
   static const ingredients = '/ingredients';

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -1,9 +1,17 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:onepan/main.dart';
 
 void main() {
   testWidgets('renders OnePan text on home screen', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'onboarding.complete': true,
+      'onboarding.country': 'US',
+      'onboarding.level': 'Beginner',
+      'onboarding.diet': 'Omnivore',
+    });
     await tester.pumpWidget(const OnePanApp());
+    await tester.pumpAndSettle();
 
     expect(find.text('OnePan'), findsOneWidget);
   });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,13 +6,21 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:onepan/main.dart';
 
 void main() {
   testWidgets('renders OnePan home route', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'onboarding.complete': true,
+      'onboarding.country': 'US',
+      'onboarding.level': 'Beginner',
+      'onboarding.diet': 'Omnivore',
+    });
     await tester.pumpWidget(const OnePanApp());
+    await tester.pumpAndSettle();
 
-    // Initial route is /home which shows centered text 'OnePan'.
+    // When onboarding is complete, home shows centered text 'OnePan'.
     expect(find.text('OnePan'), findsOneWidget);
   });
 }


### PR DESCRIPTION
- **feat(repo): add recipe repository and deterministic mock substitution with contract tests**
- **feat(ui): add token-based shared components (Button, Card, Chip, ChecklistTile, SegmentedControl, Tabs, Skeleton)**
- **feat(onboarding): 3-step Country→Level→Diet with Riverpod + SharedPreferences; route to Home on completion**
- **fixed onboarding not showing up**
