### PR TITLE
Fix onboarding back navigation regression

### DIFF
--- a/lib/features/onboarding/step_country.dart
+++ b/lib/features/onboarding/step_country.dart
@@ -98,7 +98,7 @@ class _OnboardingCountryScreenState extends ConsumerState<OnboardingCountryScree
       label: 'Next',
       onPressed: canProceed
           ? () async {
-              context.go(Routes.onboardingLevel);
+              context.push(Routes.onboardingLevel);
             }
           : null,
     );

--- a/lib/features/onboarding/step_level.dart
+++ b/lib/features/onboarding/step_level.dart
@@ -65,7 +65,7 @@ class OnboardingLevelScreen extends ConsumerWidget {
                         if (state.level == null) {
                           return;
                         }
-                        context.go(Routes.onboardingDiet);
+                        context.push(Routes.onboardingDiet);
                       }
                     : null,
               ),


### PR DESCRIPTION
## Summary
- restore the onboarding navigation stack by pushing the level and diet steps instead of replacing the current route

## Testing
- not run (dart sdk unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68ffa1beae508330a66c64a20bd7516e